### PR TITLE
Fix main target in packge.json

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -18,7 +18,7 @@
   "bugs": "https://github.com/humppa123/resilience-typescript/issues",
   "license": "MIT",
   "author": "Fabian Schwarz",
-  "main": "index.ts",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/humppa123/resilience-typescript"


### PR DESCRIPTION
Converting a legacy project over to vite and ran into this issue.
```
[ERROR] Failed to resolve entry for package "resilience-typescript". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
```

After changing the `main` entrypoint to `index.js` the issue was resovled